### PR TITLE
Make ImageScience dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>imagescience</artifactId>
+			<optional>true</optional>
 		</dependency>
 		
 		<!-- ImgLib2 dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>Trainable_Segmentation</artifactId>
-	<version>2.1.9-SNAPSHOT</version>
+	<version>2.2.0-SNAPSHOT</version>
 
 	<name>plugins/Trainable_Segmentation.jar</name>
 	<description />

--- a/src/main/java/trainableSegmentation/FeatureStack.java
+++ b/src/main/java/trainableSegmentation/FeatureStack.java
@@ -61,12 +61,6 @@ import ij.process.ColorProcessor;
 import ij.process.FloatProcessor;
 import ij.process.ImageConverter;
 import ij.process.ImageProcessor;
-import imagescience.feature.Differentiator;
-import imagescience.feature.Laplacian;
-import imagescience.feature.Structure;
-import imagescience.image.Aspects;
-import imagescience.image.FloatImage;
-import imagescience.image.Image;
 
 import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
@@ -74,7 +68,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
-import java.util.Vector;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1504,7 +1497,7 @@ public class FeatureStack
 				
 				for(int ch=0; ch < channels.length; ch++)
 				{
-					results[ch] = computeDerivativeImage(sigma, xOrder, yOrder, channels[ch]);
+					results[ch] = ImageScience.computeDerivativeImage(sigma, xOrder, yOrder, channels[ch]);
 				}
 						
 				ImagePlus newimp = mergeResultChannels(results);
@@ -1536,7 +1529,7 @@ public class FeatureStack
 		
 		for(int ch=0; ch < channels.length; ch++)
 		{
-			results[ch] = computeDerivativeImage(sigma, xOrder, yOrder, channels[ch]);
+			results[ch] = ImageScience.computeDerivativeImage(sigma, xOrder, yOrder, channels[ch]);
 		
 		}
 		ImagePlus newimp = mergeResultChannels(results);
@@ -1570,7 +1563,7 @@ public class FeatureStack
 				
 				for(int ch=0; ch < channels.length; ch++)
 				{
-					results[ch] = computeLaplacianImage(sigma, channels[ ch ]);
+					results[ch] = ImageScience.computeLaplacianImage(sigma, channels[ ch ]);
 				}
 				
 				ImagePlus newimp = mergeResultChannels(results);
@@ -1599,7 +1592,7 @@ public class FeatureStack
 		
 		for(int ch=0; ch < channels.length; ch++)
 		{
-			results[ch] = computeLaplacianImage(sigma, channels[ch]);
+			results[ch] = ImageScience.computeLaplacianImage(sigma, channels[ch]);
 			
 		}
 		
@@ -1639,7 +1632,7 @@ public class FeatureStack
 				
 				for(int ch=0; ch < channels.length; ch++)
 				{
-					final ArrayList<ImagePlus> eigenimages = computeEigenimages(sigma, integrationScale, channels[ch]);
+					final ArrayList<ImagePlus> eigenimages = ImageScience.computeEigenimages(sigma, integrationScale, channels[ch]);
 
 					final ImageStack is = new ImageStack(width, height);
 
@@ -1677,7 +1670,7 @@ public class FeatureStack
 		
 		for(int ch=0; ch < channels.length; ch++)
 		{
-			final ArrayList<ImagePlus> eigenimages = computeEigenimages(sigma, integrationScale, channels[ch]);
+			final ArrayList<ImagePlus> eigenimages = ImageScience.computeEigenimages(sigma, integrationScale, channels[ch]);
 
 			final ImageStack is = new ImageStack(width, height);
 
@@ -3387,56 +3380,6 @@ public class FeatureStack
 	public boolean isOldColorFormat()
 	{
 		return this.oldColorFormat;
-	}
-
-	// -- Methods that use ImageScience --
-
-	private static ArrayList<ImagePlus> computeEigenimages(final double sigma,
-		final double integrationScale, ImagePlus imp)
-	{
-		final Image img = Image.wrap(imp);
-		final Aspects aspects = img.aspects();
-		final Image newimg = new FloatImage(img);
-
-		final Structure structure = new Structure();
-		final Vector<Image> eigenimages = structure.run(newimg, sigma, integrationScale);
-
-		final int nrimgs = eigenimages.size();
-		for (int i=0; i<nrimgs; ++i)
-			eigenimages.get(i).aspects(aspects);
-
-		final ArrayList<ImagePlus> result = new ArrayList<ImagePlus>(nrimgs);
-		for (final Image eigenimage : eigenimages)
-			result.add(eigenimage.imageplus());
-		return result;
-	}
-	
-	private static ImagePlus computeDerivativeImage(final double sigma,
-		final int xOrder, final int yOrder, ImagePlus imp)
-	{
-		final Image img = Image.wrap(imp);
-		final Aspects aspects = img.aspects();
-		final Image newimg = new FloatImage(img);
-
-		final Differentiator diff = new Differentiator();
-
-		diff.run(newimg, sigma , xOrder, yOrder, 0);
-		newimg.aspects(aspects);
-
-		return newimg.imageplus();
-	}
-
-	private static ImagePlus computeLaplacianImage(final double sigma, ImagePlus imp) {
-		final Image img = Image.wrap(imp) ;
-		final Aspects aspects = img.aspects();
-		Image newimg = new FloatImage(img);
-
-		final Laplacian laplace = new Laplacian();
-
-		newimg = laplace.run(newimg, sigma);
-		newimg.aspects(aspects);
-
-		return newimg.imageplus();
 	}
 
 }

--- a/src/main/java/trainableSegmentation/FeatureStack.java
+++ b/src/main/java/trainableSegmentation/FeatureStack.java
@@ -155,6 +155,31 @@ public class FeatureStack
 					   	"Membrane_projections","Variance","Mean", "Minimum", "Maximum", "Median", 
 					   	"Anisotropic_diffusion", "Bilateral", "Lipschitz", "Kuwahara", "Gabor" , 
 					   	"Derivatives", "Laplacian", "Structure", "Entropy", "Neighbors"};
+
+	/** Features only available if the ImageScience library is present. */
+	public static final boolean[] IMAGESCIENCE_FEATURES = {
+		false, // Gaussian_blur
+		false, // Sobel_filter
+		false, // Hessian
+		false, // Difference_of_gaussians
+		false, // Membrane_projections
+		false, // Variance
+		false, // Mean
+		false, // Minimum
+		false, // Maximum
+		false, // Median
+		false, // Anisotropic_diffusion
+		false, // Bilateral
+		false, // Lipschitz
+		false, // Kuwahara
+		false, // Gabor
+		true,  // Derivatives
+		true,  // Laplacian
+		true,  // Structure
+		false, // Entropy
+		false  // Neighbors
+	};
+
 	/** flags of filters to be used */
 	private boolean[] enableFeatures = new boolean[]{
 			true, 	/* Gaussian_blur */

--- a/src/main/java/trainableSegmentation/FeatureStack.java
+++ b/src/main/java/trainableSegmentation/FeatureStack.java
@@ -66,6 +66,7 @@ import imagescience.feature.Laplacian;
 import imagescience.feature.Structure;
 import imagescience.image.Aspects;
 import imagescience.image.FloatImage;
+import imagescience.image.Image;
 
 import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
@@ -1503,11 +1504,11 @@ public class FeatureStack
 				
 				for(int ch=0; ch < channels.length; ch++)
 				{
-					imagescience.image.Image img = imagescience.image.Image.wrap( channels[ ch ] );
+					Image img = Image.wrap( channels[ ch ] );
 					Aspects aspects = img.aspects();
 
 
-					imagescience.image.Image newimg = new FloatImage(img);
+					Image newimg = new FloatImage(img);
 					Differentiator diff = new Differentiator();
 
 					diff.run(newimg, sigma , xOrder, yOrder, 0);
@@ -1545,11 +1546,11 @@ public class FeatureStack
 		
 		for(int ch=0; ch < channels.length; ch++)
 		{
-			final imagescience.image.Image img = imagescience.image.Image.wrap( channels[ ch ] ) ;
+			final Image img = Image.wrap( channels[ ch ] ) ;
 
 			final Aspects aspects = img.aspects();				
 
-			final imagescience.image.FloatImage newimg = new FloatImage( img );
+			final FloatImage newimg = new FloatImage( img );
 
 			final Differentiator diff = new Differentiator();
 
@@ -1591,11 +1592,11 @@ public class FeatureStack
 				
 				for(int ch=0; ch < channels.length; ch++)
 				{
-					final imagescience.image.Image img = imagescience.image.Image.wrap( channels[ ch ] ) ;
+					final Image img = Image.wrap( channels[ ch ] ) ;
 				
 					final Aspects aspects = img.aspects();				
 
-					imagescience.image.Image newimg = new FloatImage( img );
+					Image newimg = new FloatImage( img );
 
 					final Laplacian laplace = new Laplacian();
 
@@ -1632,11 +1633,11 @@ public class FeatureStack
 		
 		for(int ch=0; ch < channels.length; ch++)
 		{
-			final imagescience.image.Image img = imagescience.image.Image.wrap( channels[ ch ] ) ;
+			final Image img = Image.wrap( channels[ ch ] ) ;
 		
 			final Aspects aspects = img.aspects();				
 
-			imagescience.image.Image newimg = new FloatImage( img );
+			Image newimg = new FloatImage( img );
 
 			final Laplacian laplace = new Laplacian();
 
@@ -1683,12 +1684,12 @@ public class FeatureStack
 				
 				for(int ch=0; ch < channels.length; ch++)
 				{
-					final imagescience.image.Image img = imagescience.image.Image.wrap( channels[ ch ] ) ;
+					final Image img = Image.wrap( channels[ ch ] ) ;
 				
 					final Aspects aspects = img.aspects();				
 
 					final Structure structure = new Structure();
-					final Vector<imagescience.image.Image> eigenimages = structure.run(new FloatImage(img), sigma, integrationScale);
+					final Vector<Image> eigenimages = structure.run(new FloatImage(img), sigma, integrationScale);
 
 					final int nrimgs = eigenimages.size();
 					for (int i=0; i<nrimgs; ++i)
@@ -1730,12 +1731,12 @@ public class FeatureStack
 		
 		for(int ch=0; ch < channels.length; ch++)
 		{
-			final imagescience.image.Image img = imagescience.image.Image.wrap( channels[ ch ] ) ;
+			final Image img = Image.wrap( channels[ ch ] ) ;
 		
 			final Aspects aspects = img.aspects();				
 
 			final Structure structure = new Structure();
-			final Vector<imagescience.image.Image> eigenimages = structure.run(new FloatImage(img), sigma, integrationScale);
+			final Vector<Image> eigenimages = structure.run(new FloatImage(img), sigma, integrationScale);
 
 			final int nrimgs = eigenimages.size();
 			for (int i=0; i<nrimgs; ++i)

--- a/src/main/java/trainableSegmentation/FeatureStack.java
+++ b/src/main/java/trainableSegmentation/FeatureStack.java
@@ -1624,25 +1624,7 @@ public class FeatureStack
 		{
 			public ImagePlus call()
 			{
-				
-				// Get channel(s) to process
-				ImagePlus[] channels = extractChannels(originalImage);
-				
-				ImagePlus[] results = new ImagePlus[ channels.length ];
-				
-				for(int ch=0; ch < channels.length; ch++)
-				{
-					final ArrayList<ImagePlus> eigenimages = ImageScience.computeEigenimages(sigma, integrationScale, channels[ch]);
-
-					final ImageStack is = new ImageStack(width, height);
-
-					is.addSlice(availableFeatures[STRUCTURE] +"_largest_" + sigma + "_" + integrationScale, eigenimages.get(0).getProcessor() );
-					is.addSlice(availableFeatures[STRUCTURE] +"_smallest_" + sigma + "_" + integrationScale, eigenimages.get(1).getProcessor() );
-
-					results[ ch ] = new ImagePlus ("Structure stack", is);
-				}
-				
-				return mergeResultChannels(results);
+				return computeStructure(originalImage, sigma, integrationScale);
 			}
 		};
 	}
@@ -1662,25 +1644,7 @@ public class FeatureStack
 		if (Thread.currentThread().isInterrupted()) 
 			return;
 			
-		
-		// Get channel(s) to process
-		ImagePlus[] channels = extractChannels(originalImage);
-		
-		ImagePlus[] results = new ImagePlus[ channels.length ];
-		
-		for(int ch=0; ch < channels.length; ch++)
-		{
-			final ArrayList<ImagePlus> eigenimages = ImageScience.computeEigenimages(sigma, integrationScale, channels[ch]);
-
-			final ImageStack is = new ImageStack(width, height);
-
-			is.addSlice(availableFeatures[STRUCTURE] +"_largest_" + sigma + "_" + integrationScale, eigenimages.get(0).getProcessor() );
-			is.addSlice(availableFeatures[STRUCTURE] +"_smallest_" + sigma + "_" + integrationScale, eigenimages.get(1).getProcessor() );
-
-			results[ ch ] = new ImagePlus ("Structure stack", is);
-		}									
-		
-		ImagePlus merged = mergeResultChannels(results);
+		ImagePlus merged = computeStructure(originalImage, sigma, integrationScale);
 		
 		wholeStack.addSlice(merged.getImageStack().getSliceLabel( 1 ), merged.getImageStack().getProcessor( 1 ) );
 		wholeStack.addSlice(merged.getImageStack().getSliceLabel( 2 ), merged.getImageStack().getProcessor( 2 ) );				
@@ -3380,6 +3344,31 @@ public class FeatureStack
 	public boolean isOldColorFormat()
 	{
 		return this.oldColorFormat;
+	}
+
+	// -- Helper methods --
+
+	private ImagePlus computeStructure(final ImagePlus imp, final double sigma,
+		final double integrationScale)
+	{
+		// Get channel(s) to process
+		ImagePlus[] channels = extractChannels(imp);
+
+		ImagePlus[] results = new ImagePlus[ channels.length ];
+
+		for(int ch=0; ch < channels.length; ch++)
+		{
+			final ArrayList<ImagePlus> eigenimages = ImageScience.computeEigenimages(sigma, integrationScale, channels[ch]);
+
+			final ImageStack is = new ImageStack(width, height);
+
+			is.addSlice(availableFeatures[STRUCTURE] +"_largest_" + sigma + "_" + integrationScale, eigenimages.get(0).getProcessor() );
+			is.addSlice(availableFeatures[STRUCTURE] +"_smallest_" + sigma + "_" + integrationScale, eigenimages.get(1).getProcessor() );
+
+			results[ ch ] = new ImagePlus ("Structure stack", is);
+		}
+
+		return mergeResultChannels(results);
 	}
 
 }

--- a/src/main/java/trainableSegmentation/FeatureStack3D.java
+++ b/src/main/java/trainableSegmentation/FeatureStack3D.java
@@ -50,6 +50,7 @@ import imagescience.feature.Laplacian;
 import imagescience.feature.Structure;
 import imagescience.image.Aspects;
 import imagescience.image.FloatImage;
+import imagescience.image.Image;
 
 import java.util.ArrayList;
 import java.util.Vector;
@@ -198,11 +199,11 @@ public class FeatureStack3D
 					channel.getImageStack().addSlice("pad-back", channels[ch].getImageStack().getProcessor( channels[ ch ].getImageStackSize()));
 					channel.getImageStack().addSlice("pad-front", channels[ch].getImageStack().getProcessor( 1 ), 1);
 					
-					imagescience.image.Image img = imagescience.image.Image.wrap( channel );
+					Image img = Image.wrap( channel );
 					Aspects aspects = img.aspects();
 
 
-					imagescience.image.Image newimg = new FloatImage(img);
+					Image newimg = new FloatImage(img);
 					Differentiator diff = new Differentiator();
 					
 					diff.run(newimg, sigma , xOrder, yOrder, zOrder);
@@ -261,12 +262,12 @@ public class FeatureStack3D
 					channel.getImageStack().addSlice("pad-back", channels[ch].getImageStack().getProcessor( channels[ ch ].getImageStackSize()));
 					channel.getImageStack().addSlice("pad-front", channels[ch].getImageStack().getProcessor( 1 ), 1);
 					
-					imagescience.image.Image img = imagescience.image.Image.wrap( channel );
+					Image img = Image.wrap( channel );
 					Aspects aspects = img.aspects();
 
 
-					imagescience.image.Image newimg = new FloatImage(img);
-					imagescience.image.Image newimg2 = new FloatImage(img);
+					Image newimg = new FloatImage(img);
+					Image newimg2 = new FloatImage(img);
 					
 					Differentiator diff = new Differentiator();
 
@@ -332,15 +333,15 @@ public class FeatureStack3D
 					channel.getImageStack().addSlice("pad-back", channels[ch].getImageStack().getProcessor( channels[ ch ].getImageStackSize()));
 					channel.getImageStack().addSlice("pad-front", channels[ch].getImageStack().getProcessor( 1 ), 1);
 					
-					imagescience.image.Image img = imagescience.image.Image.wrap( channel );
+					Image img = Image.wrap( channel );
 				
 					final Aspects aspects = img.aspects();				
 
-					imagescience.image.Image newimg = new FloatImage( img );
+					Image newimg = new FloatImage( img );
 
 					final Hessian hessian = new Hessian();
 
-					final Vector<imagescience.image.Image> hessianImages = hessian.run(newimg, sigma, absolute);
+					final Vector<Image> hessianImages = hessian.run(newimg, sigma, absolute);
 					
 					final int nrimgs = hessianImages.size();
 					for (int i=0; i<nrimgs; ++i)
@@ -400,11 +401,11 @@ public class FeatureStack3D
 					channel.getImageStack().addSlice("pad-back", channels[ch].getImageStack().getProcessor( channels[ ch ].getImageStackSize()));
 					channel.getImageStack().addSlice("pad-front", channels[ch].getImageStack().getProcessor( 1 ), 1);
 					
-					imagescience.image.Image img = imagescience.image.Image.wrap( channel );
+					Image img = Image.wrap( channel );
 				
 					final Aspects aspects = img.aspects();				
 
-					imagescience.image.Image newimg = new FloatImage( img );
+					Image newimg = new FloatImage( img );
 
 					final Laplacian laplace = new Laplacian();
 
@@ -461,11 +462,11 @@ public class FeatureStack3D
 					channel.getImageStack().addSlice("pad-back", channels[ch].getImageStack().getProcessor( channels[ ch ].getImageStackSize()));
 					channel.getImageStack().addSlice("pad-front", channels[ch].getImageStack().getProcessor( 1 ), 1);
 					
-					imagescience.image.Image img = imagescience.image.Image.wrap( channel );
+					Image img = Image.wrap( channel );
 				
 					final Aspects aspects = img.aspects();				
 
-					imagescience.image.Image newimg = new FloatImage( img );
+					Image newimg = new FloatImage( img );
 
 					final Edges edges = new Edges();
 
@@ -709,12 +710,12 @@ public class FeatureStack3D
 					channel.getImageStack().addSlice("pad-back", channels[ch].getImageStack().getProcessor( channels[ ch ].getImageStackSize()));
 					channel.getImageStack().addSlice("pad-front", channels[ch].getImageStack().getProcessor( 1 ), 1);
 					
-					imagescience.image.Image img = imagescience.image.Image.wrap( channel );
+					Image img = Image.wrap( channel );
 				
 					final Aspects aspects = img.aspects();				
 
 					final Structure structure = new Structure();
-					final Vector<imagescience.image.Image> eigenimages = structure.run(new FloatImage(img), sigma, integrationScale);
+					final Vector<Image> eigenimages = structure.run(new FloatImage(img), sigma, integrationScale);
 
 					final int nrimgs = eigenimages.size();
 					for (int i=0; i<nrimgs; ++i)

--- a/src/main/java/trainableSegmentation/FeatureStack3D.java
+++ b/src/main/java/trainableSegmentation/FeatureStack3D.java
@@ -101,6 +101,22 @@ public class FeatureStack3D
 						"Structure", "Edges", "Difference_of_Gaussian", "Minimum",
 						"Maximum", "Mean", "Median", "Variance"};
 	
+	/** Features only available if the ImageScience library is present. */
+	public static final boolean[] IMAGESCIENCE_FEATURES = {
+		false, // Gaussian_blur
+		true,  // Hessian
+		true,  // Derivatives
+		true,  // Laplacian
+		true,  // Structure
+		true,  // Edges
+		true,  // Difference of Gaussian
+		false, // Minimum
+		false, // Maximum
+		false, // Mean
+		false, // Median
+		false  // Variance
+	};
+
 	/** flags of filters to be used */	
 	private boolean[] enableFeatures = new boolean[]{
 			true, 	/* Gaussian_blur */

--- a/src/main/java/trainableSegmentation/ImageScience.java
+++ b/src/main/java/trainableSegmentation/ImageScience.java
@@ -1,0 +1,128 @@
+package trainableSegmentation;
+
+import ij.ImagePlus;
+import imagescience.feature.Differentiator;
+import imagescience.feature.Edges;
+import imagescience.feature.Hessian;
+import imagescience.feature.Laplacian;
+import imagescience.feature.Structure;
+import imagescience.image.Aspects;
+import imagescience.image.FloatImage;
+import imagescience.image.Image;
+
+import java.util.ArrayList;
+import java.util.Vector;
+
+/**
+ * Helper class which encapsulates access to the optional ImageScience library.
+ */
+public final class ImageScience {
+
+	private ImageScience() {
+		// prevent instantiation of utility class
+	}
+
+	public static ArrayList<ImagePlus> computeEigenimages(final double sigma,
+		final double integrationScale, final ImagePlus imp)
+	{
+		final Image img = Image.wrap(imp);
+		final Aspects aspects = img.aspects();
+		final Image newimg = new FloatImage(img);
+
+		final Structure structure = new Structure();
+		final Vector<Image> eigenimages = structure.run(newimg, sigma, integrationScale);
+
+		final int nrimgs = eigenimages.size();
+		for (int i=0; i<nrimgs; ++i)
+			eigenimages.get(i).aspects(aspects);
+
+		final ArrayList<ImagePlus> result = new ArrayList<ImagePlus>(nrimgs);
+		for (final Image eigenimage : eigenimages)
+			result.add(eigenimage.imageplus());
+		return result;
+	}
+
+	public static ImagePlus computeDerivativeImage(final double sigma,
+		final int xOrder, final int yOrder, ImagePlus imp)
+	{
+		final Image img = Image.wrap(imp);
+		final Aspects aspects = img.aspects();
+		final Image newimg = new FloatImage(img);
+
+		final Differentiator diff = new Differentiator();
+
+		diff.run(newimg, sigma , xOrder, yOrder, 0);
+		newimg.aspects(aspects);
+
+		return newimg.imageplus();
+	}
+
+	public static ImagePlus computeLaplacianImage(final double sigma,
+		final ImagePlus imp)
+	{
+		final Image img = Image.wrap(imp) ;
+		final Aspects aspects = img.aspects();
+		Image newimg = new FloatImage(img);
+
+		final Laplacian laplace = new Laplacian();
+
+		newimg = laplace.run(newimg, sigma);
+		newimg.aspects(aspects);
+
+		return newimg.imageplus();
+	}
+
+	public static ImagePlus computeDifferentialImage(final double sigma,
+		final int xOrder, final int yOrder, final int zOrder,
+		final ImagePlus imp)
+	{
+		Image img = Image.wrap(imp);
+		Aspects aspects = img.aspects();
+
+		Image newimg = new FloatImage(img);
+		Differentiator diff = new Differentiator();
+
+		diff.run(newimg, sigma , xOrder, yOrder, zOrder);
+		newimg.aspects(aspects);
+
+		final ImagePlus ip = newimg.imageplus();
+		return ip;
+	}
+
+	public static ArrayList<ImagePlus> computeHessianImages(final double sigma,
+		final boolean absolute, final ImagePlus imp)
+	{
+		final Image img = Image.wrap(imp);
+		final Aspects aspects = img.aspects();
+
+		final Image newimg = new FloatImage(img);
+		final Hessian hessian = new Hessian();
+
+		final Vector<Image> hessianImages = hessian.run(newimg, sigma, absolute);
+
+		final int nrimgs = hessianImages.size();
+		for (int i=0; i<nrimgs; ++i)
+			hessianImages.get(i).aspects(aspects);
+
+		final ArrayList<ImagePlus> result = new ArrayList<ImagePlus>(nrimgs);
+		for (final Image hessianImage : hessianImages)
+			result.add(hessianImage.imageplus());
+		return result;
+	}
+
+	public static ImagePlus computeEdgesImage(final double sigma,
+		final ImagePlus imp)
+	{
+		final Image img = Image.wrap(imp);
+		final Aspects aspects = img.aspects();
+
+		Image newimg = new FloatImage(img);
+		final Edges edges = new Edges();
+
+		newimg = edges.run(newimg, sigma, false);
+		newimg.aspects(aspects);
+
+		return newimg.imageplus();
+	}
+
+}

--- a/src/main/java/trainableSegmentation/ImageScience.java
+++ b/src/main/java/trainableSegmentation/ImageScience.java
@@ -22,6 +22,17 @@ public final class ImageScience {
 		// prevent instantiation of utility class
 	}
 
+	/**
+	 * Tests whether the ImageScience library is installed.
+	 * 
+	 * @return true if ImageScience classes are available.
+	 * @throws NoClassDefFoundError if ImageScience classes cannot be loaded.
+	 */
+	public static boolean isAvailable() {
+		Image.class.getName();
+		return true;
+	}
+
 	public static ArrayList<ImagePlus> computeEigenimages(final double sigma,
 		final double integrationScale, final ImagePlus imp)
 	{

--- a/src/main/java/trainableSegmentation/Trainable_Segmentation.java
+++ b/src/main/java/trainableSegmentation/Trainable_Segmentation.java
@@ -2006,6 +2006,8 @@ public class Trainable_Segmentation implements PlugIn
 		final int rows = (int)Math.round(FeatureStack.availableFeatures.length/2.0);
 		gd.addCheckboxGroup(rows, 2, FeatureStack.availableFeatures, oldEnableFeatures);
 		
+		Weka_Segmentation.disableMissingFeatures(gd);
+
 		if(loadedTrainingData != null)
 		{
 			final Vector<Checkbox> v = gd.getCheckboxes();

--- a/src/main/java/trainableSegmentation/Weka_Segmentation.java
+++ b/src/main/java/trainableSegmentation/Weka_Segmentation.java
@@ -6,6 +6,7 @@ import ij.IJ;
 import ij.ImagePlus;
 import ij.Prefs;
 import ij.WindowManager;
+import ij.gui.GenericDialog;
 import ij.gui.ImageWindow;
 import ij.gui.Roi;
 import ij.gui.StackWindow;
@@ -2122,6 +2123,8 @@ public class Weka_Segmentation implements PlugIn
 		final int rows = (int)Math.round(FeatureStack.availableFeatures.length/2.0);
 		gd.addCheckboxGroup(rows, 2, FeatureStack.availableFeatures, oldEnableFeatures);
 
+		disableMissingFeatures(gd);
+
 		if(wekaSegmentation.getLoadedTrainingData() != null)
 		{
 			final Vector<Checkbox> v = gd.getCheckboxes();
@@ -3099,5 +3102,34 @@ public class Weka_Segmentation implements PlugIn
 		}
 	}	
 	
+	/** Disables features which rely on missing third party libraries. */
+	public static void disableMissingFeatures(final GenericDialog gd)
+	{
+		try {
+		if (!isImageScienceAvailable()) {
+			IJ.log("Warning: ImageScience library unavailable. " +
+				"Some training features will be disabled.");
+			@SuppressWarnings("unchecked")
+			final Vector<Checkbox> v = gd.getCheckboxes();
+			for (int i = 0; i < v.size(); i++) {
+				if (FeatureStack.IMAGESCIENCE_FEATURES[i]) {
+					v.get(i).setState(false);
+					v.get(i).setEnabled(false);
+				}
+			}
+		}
+		}
+		catch (Throwable t) { IJ.handleException(t); }
+	}
+
+	private static boolean isImageScienceAvailable() {
+		try {
+			return ImageScience.isAvailable();
+		}
+		catch (final NoClassDefFoundError err) {
+			return false;
+		}
+	}
+
 }// end of Weka_Segmentation class
 

--- a/src/main/java/trainableSegmentation/Weka_Segmentation.java
+++ b/src/main/java/trainableSegmentation/Weka_Segmentation.java
@@ -118,7 +118,8 @@ public class Weka_Segmentation implements PlugIn
 	/** plugin's name */
 	public static final String PLUGIN_NAME = "Trainable Weka Segmentation";
 	/** plugin's current version */
-	public static final String PLUGIN_VERSION = "v2.1.8";
+	public static final String PLUGIN_VERSION = "v" +
+		Weka_Segmentation.class.getPackage().getImplementationVersion();
 	
 	/** reference to the segmentation backend */
 	final WekaSegmentation wekaSegmentation;


### PR DESCRIPTION
This marks the `imagescience` dependency as optional, so that it is not automatically inherited by projects which depend on `Trainable_Segmentation`. And it makes the code work successfully even if ImageScience is not available; there are just some features which are grayed out in that case.

Fixes #4. At least well enough for now.