### PR TITLE
Entropy_Filter: scale images to min and max when converting to byte

### DIFF
--- a/src/main/java/trainableSegmentation/filters/Entropy_Filter.java
+++ b/src/main/java/trainableSegmentation/filters/Entropy_Filter.java
@@ -79,7 +79,8 @@ public class Entropy_Filter implements PlugInFilter
 			int numBins)
 	{
 		final double log2=Math.log(2.0);
-		final ByteProcessor bp = (ByteProcessor) ip.convertToByte(false);
+		ip.resetMinAndMax();
+		final ByteProcessor bp = (ByteProcessor) ip.convertToByte(true);
 		
 		bp.setHistogramRange( 0, 255 );
 		bp.setHistogramSize( numBins );


### PR DESCRIPTION
When working with 16-bit images, it could happen that all entropy slices in the feature stack where blank (i.e. all pixels at 0.0 intensity) when the signal range of the original was anywhere between 255 and 65535. This pull request tries to fix this by scaling the actual min-max intensity range when converting to byte.

An alternative approach would be to use the full 0-65535 range for scaling 16-bit images.
