### PR TITLE
squid:S2131 - Primitives should not be boxed just for String conversion

### DIFF
--- a/src/main/java/ai/BalancedRandomForest.java
+++ b/src/main/java/ai/BalancedRandomForest.java
@@ -347,13 +347,13 @@ public class BalancedRandomForest extends AbstractClassifier implements Randomiz
 		result = new Vector();
 
 		result.add("-I");
-		result.add("" + getNumTrees());
+		result.add(String.valueOf(getNumTrees()));
 
 		result.add("-K");
-		result.add("" + getNumFeatures());
+		result.add(String.valueOf(getNumFeatures()));
 
 		result.add("-S");
-		result.add("" + getSeed());
+		result.add(String.valueOf(getSeed()));
 
 
 

--- a/src/main/java/hr/irb/fastRandomForest/FastRandomForest.java
+++ b/src/main/java/hr/irb/fastRandomForest/FastRandomForest.java
@@ -456,22 +456,22 @@ public class FastRandomForest
     result = new Vector();
 
     result.add("-I");
-    result.add("" + getNumTrees());
+    result.add(String.valueOf(getNumTrees()));
 
     result.add("-K");
-    result.add("" + getNumFeatures());
+    result.add(String.valueOf(getNumFeatures()));
 
     result.add("-S");
-    result.add("" + getSeed());
+    result.add(String.valueOf(getSeed()));
 
     if(getMaxDepth() > 0){
       result.add("-depth");
-      result.add("" + getMaxDepth());
+      result.add(String.valueOf(getMaxDepth()));
     }
 
     if(getNumThreads() > 0){
       result.add("-threads");
-      result.add("" + getNumThreads());
+      result.add(String.valueOf(getNumThreads()));
     }
     
     if (getComputeImportances()) {

--- a/src/main/java/hr/irb/fastRandomForest/FastRfBagging.java
+++ b/src/main/java/hr/irb/fastRandomForest/FastRfBagging.java
@@ -514,7 +514,7 @@ class FastRfBagging extends RandomizableIteratedSingleClassifierEnhancer
 
     int current = 0;
     options[current++] = "-P";
-    options[current++] = "" + getBagSizePercent();
+    options[current++] = String.valueOf(getBagSizePercent());
 
     if (getCalcOutOfBag()) {
       options[current++] = "-O";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - Primitives should not be boxed just for "String" conversion

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131

Please let me know if you have any questions.

M-Ezzat