### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/src/main/java/hr/irb/fastRandomForest/Benchmark.java
+++ b/src/main/java/hr/irb/fastRandomForest/Benchmark.java
@@ -21,10 +21,12 @@
 package hr.irb.fastRandomForest;
 
 import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -247,8 +249,8 @@ public class Benchmark {
       result.add(myFile);
 
     } else {
-
-      BufferedReader bufRdr = new BufferedReader(new FileReader(fileOrDir));
+      FileInputStream fileInputStream = new FileInputStream(fileOrDir);
+      BufferedReader bufRdr = new BufferedReader(new InputStreamReader(fileInputStream, StandardCharsets.UTF_8));
       String line = null;
       while ((line = bufRdr.readLine()) != null) {
         if (line.endsWith(myExt))
@@ -256,7 +258,8 @@ public class Benchmark {
         else
           result.add(new File(line + myExt));
       }
-
+      fileInputStream.close();
+      bufRdr.close();
     }
 
     return result;

--- a/src/main/java/trainableSegmentation/FeatureStack.java
+++ b/src/main/java/trainableSegmentation/FeatureStack.java
@@ -67,6 +67,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -759,7 +760,7 @@ public class FeatureStack
 		try{
 			BufferedWriter out = new BufferedWriter(
 					new OutputStreamWriter(
-							new FileOutputStream(filename) ) );
+							new FileOutputStream(filename), StandardCharsets.UTF_8) );
 			try{	
 				for (int i=1; i <= wholeStack.getSize(); i++)
 				{

--- a/src/main/java/trainableSegmentation/Trainable_Segmentation.java
+++ b/src/main/java/trainableSegmentation/Trainable_Segmentation.java
@@ -86,9 +86,11 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -821,7 +823,7 @@ public class Trainable_Segmentation implements PlugIn
 		try{
 			BufferedWriter out = new BufferedWriter(
 					new OutputStreamWriter(
-							new FileOutputStream( filename) ) );
+							new FileOutputStream( filename), StandardCharsets.UTF_8) );
 			try{	
 				out.write(data.toString());
 				out.close();
@@ -840,7 +842,8 @@ public class Trainable_Segmentation implements PlugIn
 	public Instances readDataFromARFF(String filename){
 		try{
 			BufferedReader reader = new BufferedReader(
-					new FileReader(filename));
+					new InputStreamReader(
+							new FileInputStream(filename), StandardCharsets.UTF_8));
 			try{
 				Instances data = new Instances(reader);
 				// setting class attribute

--- a/src/main/java/trainableSegmentation/WekaSegmentation.java
+++ b/src/main/java/trainableSegmentation/WekaSegmentation.java
@@ -8,13 +8,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -3644,7 +3645,8 @@ public class WekaSegmentation {
 	public Instances readDataFromARFF(String filename){
 		try{
 			BufferedReader reader = new BufferedReader(
-					new FileReader(filename));
+					new InputStreamReader(
+							new FileInputStream(filename), StandardCharsets.UTF_8));
 			try{
 				Instances data = new Instances(reader);
 				// setting class attribute
@@ -3669,7 +3671,7 @@ public class WekaSegmentation {
 		try{
 			out = new BufferedWriter(
 					new OutputStreamWriter(
-							new FileOutputStream( filename ) ) );
+							new FileOutputStream( filename ), StandardCharsets.UTF_8 ) );
 
 			final Instances header = new Instances(data, 0);
 			out.write(header.toString());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat