### PR TITLE
squid:S1197 - Array designators "[]" should be on the type, not the variable

### DIFF
--- a/src/main/java/trainableSegmentation/FeatureStackArray.java
+++ b/src/main/java/trainableSegmentation/FeatureStackArray.java
@@ -42,7 +42,7 @@ import java.util.concurrent.Future;
 public class FeatureStackArray 
 {
 	/** array of feature stacks */
-	private FeatureStack featureStackArray[];
+	private FeatureStack[] featureStackArray;
 	
 	/** index of the feature stack that is used as reference (to read attribute, etc.).
 	 * -1 if not definded yet. */

--- a/src/main/java/trainableSegmentation/Trainable_Segmentation.java
+++ b/src/main/java/trainableSegmentation/Trainable_Segmentation.java
@@ -140,7 +140,7 @@ public class Trainable_Segmentation implements PlugIn
 	/** GUI window */
 	private CustomWindow win;
 	/** array of number of traces per class */
-	private int traceCounter[] = new int[MAX_NUM_CLASSES];
+	private int[] traceCounter = new int[MAX_NUM_CLASSES];
 	/** flag to display the overlay image */
 	private boolean showColorOverlay;
 	/** set of instances for the whole training image */
@@ -189,7 +189,7 @@ public class Trainable_Segmentation implements PlugIn
 	/** current number of classes */
 	private int numOfClasses = 2;
 	/** array of trace lists for every class */
-	private java.awt.List exampleList[];
+	private java.awt.List[] exampleList;
 	/** array of buttons for adding each trace class */
 	private JButton [] addExampleButton;
 	
@@ -1139,7 +1139,7 @@ public class Trainable_Segmentation implements PlugIn
 		final double[][] results = new double[numThreads][];
 		final Instances[] partialData = new Instances[numThreads];
 		final int partialSize = data.numInstances() / numThreads;
-		Future<double[]> fu[] = new Future[numThreads];
+		Future<double[]>[] fu = new Future[numThreads];
 		
 		final AtomicInteger counter = new AtomicInteger();
 		
@@ -1227,7 +1227,7 @@ public class Trainable_Segmentation implements PlugIn
 		final double[][][] results = new double[numThreads][][];
 		final Instances[] partialData = new Instances[numThreads];
 		final int partialSize = data.numInstances() / numThreads;
-		Future<double[][]> fu[] = new Future[numThreads];
+		Future<double[][]>[] fu = new Future[numThreads];
 		
 		final AtomicInteger counter = new AtomicInteger();
 		

--- a/src/main/java/trainableSegmentation/WekaSegmentation.java
+++ b/src/main/java/trainableSegmentation/WekaSegmentation.java
@@ -98,7 +98,7 @@ public class WekaSegmentation {
 
 	/** array of lists of Rois for each slice (vector index)
 	 * and each class (arraylist index) of the training image */
-	private Vector<ArrayList<Roi>> examples[];
+	private Vector<ArrayList<Roi>>[] examples;
 	/** image to be used in the training */
 	private ImagePlus trainingImage;
 	/** result image after classification */
@@ -122,10 +122,10 @@ public class WekaSegmentation {
 	private boolean updateFeatures = false;
 
 	/** array of boolean flags to update (or not) specific feature stacks during training */
-	private boolean featureStackToUpdateTrain[];
+	private boolean[] featureStackToUpdateTrain;
 
 	/** array of boolean flags to update (or not) specific feature stacks during test */
-	private boolean featureStackToUpdateTest[];
+	private boolean[] featureStackToUpdateTest;
 
 	/** current number of classes */
 	private int numOfClasses = 0;
@@ -4581,11 +4581,11 @@ public class WekaSegmentation {
 		int numOfRows = height * imp.getImageStackSize() / numThreads;
 
 		// set each slice in a thread
-		Future<ArrayList <ImagePlus> > fu[] = new Future [ numThreads ];
+		Future<ArrayList <ImagePlus> >[] fu = new Future [ numThreads ];
 
 		ArrayList<int[]> imagePad = new ArrayList<int[]>();
 
-		ArrayList <ImagePlus> list[] = new ArrayList [ numThreads ];
+		ArrayList <ImagePlus>[] list = new ArrayList [ numThreads ];
 
 		// Divide work among available threads
 		//IJ.log("Dividing image data among the " + numThreads + " available threads...");
@@ -5313,7 +5313,7 @@ public class WekaSegmentation {
 				futures.add( exe.submit( createInstances(classNames, featureStackArray.get(z-1))) );
 			}
 
-			Instances data[] = new Instances[ futures.size() ];
+			Instances[] data = new Instances[ futures.size() ];
 
 			for(int z = 1; z<=trainingImage.getImageStackSize(); z++)
 			{
@@ -5386,7 +5386,7 @@ public class WekaSegmentation {
 		final double[][][] results = new double[numThreads][][];
 		final Instances[] partialData = new Instances[numThreads];
 		final int partialSize = numInstances / numThreads;
-		Future<double[][]> fu[] = new Future[numThreads];
+		Future<double[][]>[] fu = new Future[numThreads];
 
 		final AtomicInteger counter = new AtomicInteger();
 
@@ -5547,7 +5547,7 @@ public class WekaSegmentation {
 		exe = Executors.newFixedThreadPool(numThreads);
 		final double[][][] results = new double[numThreads][][];
 		final int partialSize = numInstances / numThreads;
-		Future<double[][]> fu[] = new Future[numThreads];
+		Future<double[][]>[] fu = new Future[numThreads];
 
 		final AtomicInteger counter = new AtomicInteger();
 

--- a/src/main/java/trainableSegmentation/Weka_Segmentation.java
+++ b/src/main/java/trainableSegmentation/Weka_Segmentation.java
@@ -135,7 +135,7 @@ public class Weka_Segmentation implements PlugIn
 	/** number of classes in the GUI */
 	private int numOfClasses;
 	/** array of number of traces per class */
-	private int traceCounter[] = new int[WekaSegmentation.MAX_NUM_CLASSES];
+	private int[] traceCounter = new int[WekaSegmentation.MAX_NUM_CLASSES];
 	/** flag to display the overlay image */
 	private boolean showColorOverlay;
 	/** executor service to launch threads for the plugin methods and events */
@@ -179,7 +179,7 @@ public class Weka_Segmentation implements PlugIn
 	private LUT overlayLUT;
 
 	/** array of trace lists for every class */
-	private java.awt.List exampleList[];
+	private java.awt.List[] exampleList;
 	/** array of buttons for adding each trace class */
 	private JButton [] addExampleButton;
 	

--- a/src/main/java/trainableSegmentation/metrics/PixelError.java
+++ b/src/main/java/trainableSegmentation/metrics/PixelError.java
@@ -629,7 +629,7 @@ public class PixelError extends Metrics
      *
      * @param args arguments to decide the action
      */
-    public static void main(String args[]) 
+    public static void main(String[] args)
     {
        if (args.length<1) 
        {

--- a/src/main/java/trainableSegmentation/metrics/RandError.java
+++ b/src/main/java/trainableSegmentation/metrics/RandError.java
@@ -2138,7 +2138,7 @@ public class RandError extends Metrics
      *
      * @param args arguments to decide the action
      */
-    public static void main(String args[]) 
+    public static void main(String[] args)
     {
        if (args.length<1) 
        {

--- a/src/main/java/trainableSegmentation/metrics/WarpingError.java
+++ b/src/main/java/trainableSegmentation/metrics/WarpingError.java
@@ -1298,8 +1298,8 @@ public class WarpingError extends Metrics {
 			diff_before = diff;
 
 			// Count mismatches
-			float pixels[] = (float[]) missclass_points_image.getPixels();
-			float mask_pixels[] = (null != maskReal) ? (float[]) maskReal.getProcessor().getPixels() : new float[pixels.length];
+			float[] pixels = (float[]) missclass_points_image.getPixels();
+			float[] mask_pixels = (null != maskReal) ? (float[]) maskReal.getProcessor().getPixels() : new float[pixels.length];
 			if(null == maskReal)
 				Arrays.fill(mask_pixels, 1f);
 
@@ -2670,7 +2670,7 @@ public class WarpingError extends Metrics {
      *
      * @param args arguments to decide the action
      */
-    public static void main(String args[]) 
+    public static void main(String[] args)
     {
        if (args.length<1) 
        {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - Array designators "[]" should be on the type, not the variable

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197

Please let me know if you have any questions.

M-Ezzat