### PR TITLE
Cleanup - squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/hr/irb/fastRandomForest/Benchmark.java
+++ b/src/main/java/hr/irb/fastRandomForest/Benchmark.java
@@ -55,11 +55,15 @@ import weka.experiment.PairedStatsCorrected;
  * 
  * @author Fran Supek (fran.supek[AT]irb.hr)
  */
-public class Benchmark {
+public final class Benchmark {
 
   public static final int numRuns = 10;
 
   public static final int numFolds = 10;
+
+  private Benchmark() throws InstantiationException {
+      throw new InstantiationException("This class is not created for instantiation");
+  }
 
   public static void main(String[] args) throws Exception {
 

--- a/src/main/java/hr/irb/fastRandomForest/FastRfUtils.java
+++ b/src/main/java/hr/irb/fastRandomForest/FastRfUtils.java
@@ -38,8 +38,11 @@ import weka.core.Instances;
  * @author Julien Prados - original code
  * @author Fran Supek (fran.supek[AT]irb.hr) - adapted code
  */
-public class FastRfUtils {
+public final class FastRfUtils {
 
+  private FastRfUtils() throws InstantiationException {
+      throw new InstantiationException("This class is not created for instantiation");
+  }
 
   /**
    * Sorts a given array of floats in ascending order and returns an

--- a/src/main/java/hr/irb/fastRandomForest/SplitCriteria.java
+++ b/src/main/java/hr/irb/fastRandomForest/SplitCriteria.java
@@ -32,9 +32,12 @@ package hr.irb.fastRandomForest;
  * @author Fran Supek (fran.supek[AT]irb.hr) - adapted code
  * @version 0.9
  */
-public class SplitCriteria {
-  
-  
+public final class SplitCriteria {
+
+  private SplitCriteria() throws InstantiationException {
+      throw new InstantiationException("This class is not created for instantiation");
+  }
+
   /**
    * Similar to weka.core.ContingencyTables.entropyConditionedOnRows.
    * 

--- a/src/main/java/trainableSegmentation/utils/PrincipalComponentAnalysis.java
+++ b/src/main/java/trainableSegmentation/utils/PrincipalComponentAnalysis.java
@@ -38,8 +38,12 @@ import org.apache.commons.math3.linear.SingularValueDecomposition;
  * @author Ignacio Arganda-Carreras (iarganda at mit dot edu)
  *
  */
-public class PrincipalComponentAnalysis 
+public final class PrincipalComponentAnalysis 
 {
+
+    private PrincipalComponentAnalysis() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
 	public static ImagePlus getPrincipalComponents(
 			final ImagePlus inputImage,

--- a/src/main/java/trainableSegmentation/utils/Utils.java
+++ b/src/main/java/trainableSegmentation/utils/Utils.java
@@ -45,8 +45,12 @@ import util.FindConnectedRegions.Results;
 /**
  * This class implements useful methods for the Weka Segmentation library.
  */
-public class Utils {
-	
+public final class Utils {
+
+    private Utils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
 	/**
 	 * Connected components based on Find Connected Regions (from Mark Longair)
 	 * @param im input image


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat