### PR TITLE
Update weka to 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,25 @@
 		<dependency>
 			<groupId>nz.ac.waikato.cms.weka</groupId>
 			<artifactId>weka-dev</artifactId>
+			<version>3.9.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.github.fommil.netlib</groupId>
+					<artifactId>all</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>nz.ac.waikato.cms.weka.thirdparty</groupId>
+					<artifactId>java-cup-11b</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>nz.ac.waikato.cms.weka.thirdparty</groupId>
+					<artifactId>java-cup-11b-runtime</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.googlecode.netlib-java</groupId>
+					<artifactId>netlib-java</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/trainableSegmentation/Weka_Segmentation.java
+++ b/src/main/java/trainableSegmentation/Weka_Segmentation.java
@@ -81,6 +81,7 @@ import weka.core.OptionHandler;
 import weka.core.SerializationHelper;
 import weka.core.Utils;
 import weka.gui.GUIChooser;
+import weka.gui.GUIChooserApp;
 import weka.gui.GenericObjectEditor;
 import weka.gui.PropertyPanel;
 import weka.gui.beans.PluginManager;
@@ -2103,7 +2104,7 @@ public class Weka_Segmentation implements PlugIn
 	 */
 	public static void launchWeka()
 	{
-		GUIChooser chooser = new GUIChooser();
+		GUIChooserApp chooser = new GUIChooserApp();
 		for (WindowListener wl : chooser.getWindowListeners())
 		{
 			chooser.removeWindowListener(wl);

--- a/src/main/java/trainableSegmentation/Weka_Segmentation.java
+++ b/src/main/java/trainableSegmentation/Weka_Segmentation.java
@@ -83,7 +83,7 @@ import weka.core.Utils;
 import weka.gui.GUIChooserApp;
 import weka.gui.GenericObjectEditor;
 import weka.gui.PropertyPanel;
-import weka.gui.beans.PluginManager;
+import weka.core.PluginManager;
 import weka.gui.visualize.PlotData2D;
 import weka.gui.visualize.ThresholdVisualizePanel;
 

--- a/src/main/java/trainableSegmentation/Weka_Segmentation.java
+++ b/src/main/java/trainableSegmentation/Weka_Segmentation.java
@@ -80,7 +80,6 @@ import weka.core.Instances;
 import weka.core.OptionHandler;
 import weka.core.SerializationHelper;
 import weka.core.Utils;
-import weka.gui.GUIChooser;
 import weka.gui.GUIChooserApp;
 import weka.gui.GenericObjectEditor;
 import weka.gui.PropertyPanel;


### PR DESCRIPTION
This eliminates the horrible stream of exceptions printed to the console when TWS first spins up.

We exclude some of weka's dependency tree which does not seem to be needed for our use case—although I admit I did not test very thoroughly.

@iarganda Is this something you have tried to do previously? Any obstacles here? Or do you think it will be OK?