### PR TITLE
Fix hessian eigenvalue calculation in FeatureStack

### DIFF
--- a/src/main/java/trainableSegmentation/FeatureStack.java
+++ b/src/main/java/trainableSegmentation/FeatureStack.java
@@ -221,8 +221,10 @@ public class FeatureStack
 	private final boolean colorFeatures;
 	
 	/** flag to specify the use of the old color format (using directly the RGB values as float) */
-	private boolean oldColorFormat = false; 
-	
+	private boolean oldColorFormat = false;
+	/** flag to specify the use of the old (wrong) Hessian format (fixed in
+	 * version 3.2.25 of TWS) */
+	private boolean oldHessianFormat = false;
 	/** executor service to produce concurrent threads */
 	private ExecutorService exe = null;
 	
@@ -1006,10 +1008,21 @@ public class FeatureStack
 
 				// Ratio
 				//ipRatio.setf(x,y, (float)(trace*trace) / determinant);
-				// First eigenvalue: (a + d + sqrt( ( 4*b^2 + (a - d)^2 ) ) / 2
-				ipEig1.setf(x,y, (float) ( trace + Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) ) ) / 2 );
-				// Second eigenvalue: (a + d - sqrt( ( 4*b^2 + (a - d)^2) ) / 2
-				ipEig2.setf(x,y, (float) ( trace - Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) ) ) / 2 );
+				// First and second eigenvalues
+				if( this.isOldHessianFormat() )
+				{
+					// First eigenvalue: (a + d) / 2 + sqrt( ( 4*b^2 + (a - d)^2) / 2 )
+					ipEig1.setf(x,y, (float) ( trace/2.0 + Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) / 2.0 ) ) );
+					// Second eigenvalue: (a + d) / 2 - sqrt( ( 4*b^2 + (a - d)^2) / 2 )
+					ipEig2.setf(x,y, (float) ( trace/2.0 - Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) / 2.0 ) ) );
+				}
+				else
+				{
+					// First eigenvalue: (a + d + sqrt( ( 4*b^2 + (a - d)^2 ) ) / 2
+					ipEig1.setf(x,y, (float) ( trace + Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) ) ) / 2 );
+					// Second eigenvalue: (a + d - sqrt( ( 4*b^2 + (a - d)^2) ) / 2
+					ipEig2.setf(x,y, (float) ( trace - Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) ) ) / 2 );
+				}
 				// Orientation
 				if (s_xy < 0.0) // -0.5 * acos( (a-d) / sqrt( 4*b^2 + (a - d)^2)) )
 				{
@@ -3514,14 +3527,32 @@ public class FeatureStack
 	}
 	
 	/**
-	 * Check if the feature stack is using the old color format.
+	 * Check if the feature stack is using the old Hessian format (previous to
+	 * TWS 3.2.25).
 	 * @return true if the feature stack is using the old color format
 	 */
 	public boolean isOldColorFormat()
 	{
 		return this.oldColorFormat;
 	}
+	/**
+	 * Set the use of old Hessian format.
+	 * @param b flag to set the use of old color format
+	 */
+	public void setOldHessianFormat( boolean b )
+	{
+		this.oldHessianFormat = b;
+	}
 
+	/**
+	 * Check if the feature stack is using the old Hessian format (previous to
+	 * TWS version 3.2.25).
+	 * @return true if the feature stack is using the old Hessian format
+	 */
+	public boolean isOldHessianFormat()
+	{
+		return this.oldHessianFormat;
+	}
 	// -- Helper methods --
 
 	private ImagePlus computeStructure(final ImagePlus imp, final double sigma,

--- a/src/main/java/trainableSegmentation/FeatureStack.java
+++ b/src/main/java/trainableSegmentation/FeatureStack.java
@@ -1006,10 +1006,10 @@ public class FeatureStack
 
 				// Ratio
 				//ipRatio.setf(x,y, (float)(trace*trace) / determinant);
-				// First eigenvalue: (a + d) / 2 + sqrt( ( 4*b^2 + (a - d)^2) / 2 )
-				ipEig1.setf(x,y, (float) ( trace/2.0 + Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) / 2.0 ) ) );
-				// Second eigenvalue: (a + d) / 2 - sqrt( ( 4*b^2 + (a - d)^2) / 2 )
-				ipEig2.setf(x,y, (float) ( trace/2.0 - Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) / 2.0 ) ) );
+				// First eigenvalue: (a + d + sqrt( ( 4*b^2 + (a - d)^2 ) ) / 2
+				ipEig1.setf(x,y, (float) ( trace + Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) ) ) / 2 );
+				// Second eigenvalue: (a + d - sqrt( ( 4*b^2 + (a - d)^2) ) / 2
+				ipEig2.setf(x,y, (float) ( trace - Math.sqrt((4*s_xy*s_xy + (s_xx - s_yy)*(s_xx - s_yy)) ) ) / 2 );
 				// Orientation
 				if (s_xy < 0.0) // -0.5 * acos( (a-d) / sqrt( 4*b^2 + (a - d)^2)) )
 				{

--- a/src/main/java/trainableSegmentation/FeatureStackArray.java
+++ b/src/main/java/trainableSegmentation/FeatureStackArray.java
@@ -62,8 +62,10 @@ public class FeatureStackArray
 	private boolean[] enabledFeatures = null;
 	
 	/** flag to specify the use of the old color format (using directly the RGB values as float) */
-	private boolean oldColorFormat = false;  
-	
+	private boolean oldColorFormat = false;
+	/** flag to specify the use of the old (wrong) Hessian format (fixed in
+	 * version 3.2.25 of TWS) */
+	private boolean oldHessianFormat = false;
 	/**
 	 * Initialize a feature stack list of a specific size (with default values
 	 * for the rest of parameters).
@@ -143,7 +145,21 @@ public class FeatureStackArray
 	{
 		return featureStackArray[n];
 	}
-	
+	/**
+	 * Return if image stacks are RGB or grayscale.
+	 * @return true if image feature stacks are RGB, false if grayscale
+	 */
+	public boolean isRGB()
+	{
+		if( this.referenceStackIndex != -1 )
+			return this.featureStackArray[ referenceStackIndex ]
+					.getStack().getBitDepth() == 24;
+		else
+		{
+			IJ.log("Warning. Error in FeatureStackArray: trying to access empty array!");
+			return false;
+		}
+	}
 	/**
 	 * Set a member of the list
 	 * @param fs new feature stack  
@@ -185,6 +201,8 @@ public class FeatureStackArray
 						featureStackArray[i].setMaximumSigma(maximumSigma);
 						featureStackArray[i].setMinimumSigma(minimumSigma);
 						featureStackArray[i].setUseNeighbors(useNeighbors);
+						featureStackArray[i].setOldColorFormat(oldColorFormat);
+						featureStackArray[i].setOldHessianFormat(oldHessianFormat);
 						if ( featureStackArray.length == 1 )
 						{
 							if( !featureStackArray[i].updateFeaturesMT() )
@@ -252,6 +270,8 @@ public class FeatureStackArray
 					featureStackArray[i].setMaximumSigma(maximumSigma);
 					featureStackArray[i].setMinimumSigma(minimumSigma);
 					featureStackArray[i].setUseNeighbors(useNeighbors);
+					featureStackArray[i].setOldColorFormat(oldColorFormat);
+					featureStackArray[i].setOldHessianFormat(oldHessianFormat);
 					if ( featureStackArray.length == 1 )
 					{
 						if(!featureStackArray[i].updateFeaturesMT())
@@ -508,7 +528,7 @@ public class FeatureStackArray
 	}
 	
 	/**
-	 * Set the user of the old color format.
+	 * Set the use of the old color format.
 	 * @param oldColorFormat true if old color format is to be used
 	 */
 	public void setOldColorFormat( boolean oldColorFormat ) 
@@ -526,7 +546,27 @@ public class FeatureStackArray
 	{
 		return this.oldColorFormat;
 	}
+	/**
+	 * Specify the use of the old (wrong) Hessian format (fixed in
+	 * version 3.2.25 of TWS)
+	 * @param oldHessianFormat true if old Hessian format is to be used
+	 */
+	public void setOldHessianFormat( boolean oldHessianFormat )
+	{
+		this.oldHessianFormat = oldHessianFormat;
+		if( referenceStackIndex != -1 )
+			featureStackArray[ referenceStackIndex ]
+					.setOldHessianFormat( oldHessianFormat );
+	}
 	
+	/**
+	 * Check if the old Hessian format is used.
+	 * @return true if the old Hessian format is used
+	 */
+	public boolean isOldoldHessianFormatFormat()
+	{
+		return this.oldHessianFormat;
+	}
 }
 
 	

--- a/src/test/java/trainableSegmentation/BasicTest.java
+++ b/src/test/java/trainableSegmentation/BasicTest.java
@@ -76,6 +76,7 @@ public class BasicTest
 
 		// process
 		final FeatureStack featureStack = new FeatureStack(bridge);
+		featureStack.setOldHessianFormat(true);
 		updateFeaturesMethod.accept(featureStack);
 		final ImagePlus features = new ImagePlus("features", featureStack.getStack());
 		// test
@@ -99,6 +100,7 @@ public class BasicTest
 
 		FastRandomForest rf = (FastRandomForest) segmentator.getClassifier();
 		rf.setSeed( 69 );
+		segmentator.getFeatureStackArray().setOldHessianFormat(true);
 		assertTrue( segmentator.trainClassifier() );
 
 		segmentator.applyClassifier( false );

--- a/src/test/java/trainableSegmentation/FeatureStackTest.java
+++ b/src/test/java/trainableSegmentation/FeatureStackTest.java
@@ -1,0 +1,66 @@
+package trainableSegmentation;
+
+import ij.IJ;
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.process.ImageProcessor;
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+
+public class FeatureStackTest {
+
+	@Test
+	public void testHessian() {
+		ImagePlus input = createTestImage();
+		ImageStack stack = calculateSingleFeature(input, "Hessian");
+		float eigenvalue1 = getCenterPixel(getProcessorBySliceLabel(stack, "Hessian_Eigenvalue_1_0.0"));
+		float eigenvalue2 = getCenterPixel(getProcessorBySliceLabel(stack, "Hessian_Eigenvalue_2_0.0"));
+		double expectedEigenvalue1 = Math.sqrt(5) + 2; // first eigenvalue of the matrix [1 2; 2 3]
+		double expectedEigenvalue2 = -Math.sqrt(5) + 2; // second eigenvalue of the matrix [1 2; 2 3]
+		int factor = 64;
+		assertEquals(expectedEigenvalue1, eigenvalue1 / factor, 0.0001);
+		assertEquals(expectedEigenvalue2, eigenvalue2 / factor, 0.0001);
+	}
+
+	/**
+	 * Returns an image, whose hessian matrix is equal to:
+	 * [1 2]
+	 * [2 3]
+	 * for every pixel.
+	 */
+	private ImagePlus createTestImage() {
+		ImagePlus input = IJ.createImage("input", 8, 8, 1, 32);
+		ImageProcessor processor = input.getProcessor();
+		for (int y = 0; y < processor.getHeight(); y++)
+			for (int x = 0; x < processor.getHeight(); x++) {
+				processor.setf(x, y, 0.5f * 1 * x * x + 2 * x * y + 0.5f * 3 * y * y);
+			}
+		return input;
+	}
+
+	private ImageStack calculateSingleFeature(ImagePlus input, String featureName) {
+		FeatureStack featureStack = new FeatureStack(input);
+		featureStack.setMinimumSigma(1);
+		featureStack.setMaximumSigma(1);
+		featureStack.setEnabledFeatures(new boolean[20]);
+		featureStack.setEnabledFeature(featureName, true);
+		featureStack.updateFeaturesST();
+		return featureStack.getStack();
+	}
+
+	private ImageProcessor getProcessorBySliceLabel(ImageStack stack, String sliceLabel) {
+		for (int i = 1; i <= stack.getSize(); i++) {
+			if (sliceLabel.equals(stack.getSliceLabel(i)))
+				return stack.getProcessor(i);
+		}
+		throw new NoSuchElementException();
+	}
+
+	private float getCenterPixel(ImageProcessor imageProcessor) {
+		return imageProcessor.getf(imageProcessor.getWidth() / 2, imageProcessor.getHeight() / 2);
+	}
+
+}


### PR DESCRIPTION
This PR fixes the eigenvalue calculation in FeatureStack. Some parenthesis were wrongly placed
in previous versions of the eigenvalue calculation.
I added a unit test to make sure that the eigenvalue calculated are now correct.

I'm worried about merging this PR. This change fixes the hessian eigenvalue calculation but at the same time it's NOT BACKWARD COMPATIBLE. If a user opens an saved classifier, they will get  wrong / different results.